### PR TITLE
feat: implement secure two-step admin transfer (propose → accept)

### DIFF
--- a/contracts/staking/src/events.rs
+++ b/contracts/staking/src/events.rs
@@ -70,6 +70,33 @@ pub struct LockPeriodSetEvent {
     pub timestamp: u64,
 }
 
+/// Fired when an admin transfer is proposed.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Fired when an admin transfer is accepted.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Fired when a pending admin transfer is cancelled.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_proposed: Address,
+    pub timestamp: u64,
+}
+
 // ── Publishers ──────────────────────────────────────────────────────────────
 
 pub fn publish_initialized(
@@ -162,6 +189,39 @@ pub fn publish_lock_period_set(env: &Env, new_period: u64) {
         (symbol_short!("LOCK_SET"),),
         LockPeriodSetEvent {
             new_period,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn publish_admin_transfer_proposed(env: &Env, current_admin: Address, proposed_admin: Address) {
+    env.events().publish(
+        (symbol_short!("ADM_PROP"), current_admin.clone()),
+        AdminTransferProposedEvent {
+            current_admin,
+            proposed_admin,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn publish_admin_transfer_accepted(env: &Env, old_admin: Address, new_admin: Address) {
+    env.events().publish(
+        (symbol_short!("ADM_ACPT"), new_admin.clone()),
+        AdminTransferAcceptedEvent {
+            old_admin,
+            new_admin,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn publish_admin_transfer_cancelled(env: &Env, admin: Address, cancelled_proposed: Address) {
+    env.events().publish(
+        (symbol_short!("ADM_CNCL"), admin.clone()),
+        AdminTransferCancelledEvent {
+            admin,
+            cancelled_proposed,
             timestamp: env.ledger().timestamp(),
         },
     );

--- a/contracts/vision_records/src/events.rs
+++ b/contracts/vision_records/src/events.rs
@@ -14,6 +14,33 @@ pub struct InitializedEvent {
     pub timestamp: u64,
 }
 
+/// Event published when an admin transfer is proposed.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Event published when an admin transfer is accepted.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Event published when a pending admin transfer is cancelled.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_proposed: Address,
+    pub timestamp: u64,
+}
+
 /// Event published when a new user is registered.
 #[soroban_sdk::contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -113,6 +140,36 @@ pub struct ContractResumedEvent {
     pub caller: Address,
     pub scope: PauseScope,
     pub timestamp: u64,
+}
+
+pub fn publish_admin_transfer_proposed(env: &Env, current_admin: Address, proposed_admin: Address) {
+    let topics = (symbol_short!("ADM_PROP"), current_admin.clone());
+    let data = AdminTransferProposedEvent {
+        current_admin,
+        proposed_admin,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(topics, data);
+}
+
+pub fn publish_admin_transfer_accepted(env: &Env, old_admin: Address, new_admin: Address) {
+    let topics = (symbol_short!("ADM_ACPT"), new_admin.clone());
+    let data = AdminTransferAcceptedEvent {
+        old_admin,
+        new_admin,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(topics, data);
+}
+
+pub fn publish_admin_transfer_cancelled(env: &Env, admin: Address, cancelled_proposed: Address) {
+    let topics = (symbol_short!("ADM_CNCL"), admin.clone());
+    let data = AdminTransferCancelledEvent {
+        admin,
+        cancelled_proposed,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(topics, data);
 }
 
 pub fn publish_initialized(env: &Env, admin: Address) {

--- a/contracts/vision_records/src/lib.rs
+++ b/contracts/vision_records/src/lib.rs
@@ -43,6 +43,7 @@ pub use prescription::{LensType, OptionalContactLensData, Prescription, Prescrip
 
 /// Storage keys for the contract
 const ADMIN: Symbol = symbol_short!("ADMIN");
+const PENDING_ADMIN: Symbol = symbol_short!("PEND_ADM");
 const INITIALIZED: Symbol = symbol_short!("INIT");
 const RATE_CFG: Symbol = symbol_short!("RL_CFG");
 const RATE_TRACK: Symbol = symbol_short!("RL_TRK");
@@ -316,6 +317,82 @@ impl VisionRecordsContract {
     /// Check if the contract is initialized
     pub fn is_initialized(env: Env) -> bool {
         env.storage().instance().has(&INITIALIZED)
+    }
+
+    /// Propose a new admin address. Only the current admin can call this.
+    /// The new admin must call `accept_admin` to complete the transfer.
+    pub fn propose_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
+        current_admin.require_auth();
+
+        let admin = Self::get_admin(env.clone())?;
+        if current_admin != admin {
+            return Err(ContractError::Unauthorized);
+        }
+
+        env.storage().instance().set(&PENDING_ADMIN, &new_admin);
+
+        events::publish_admin_transfer_proposed(&env, current_admin, new_admin);
+
+        Ok(())
+    }
+
+    /// Accept the pending admin transfer. Only the proposed new admin can call this.
+    /// Completes the two-step admin transfer process.
+    pub fn accept_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {
+        new_admin.require_auth();
+
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_ADMIN)
+            .ok_or(ContractError::InvalidInput)?;
+
+        if new_admin != pending {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let old_admin = Self::get_admin(env.clone())?;
+
+        env.storage().instance().set(&ADMIN, &new_admin);
+        env.storage().instance().remove(&PENDING_ADMIN);
+
+        events::publish_admin_transfer_accepted(&env, old_admin, new_admin);
+
+        Ok(())
+    }
+
+    /// Cancel a pending admin transfer. Only the current admin can call this.
+    pub fn cancel_admin_transfer(
+        env: Env,
+        current_admin: Address,
+    ) -> Result<(), ContractError> {
+        current_admin.require_auth();
+
+        let admin = Self::get_admin(env.clone())?;
+        if current_admin != admin {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_ADMIN)
+            .ok_or(ContractError::InvalidInput)?;
+
+        env.storage().instance().remove(&PENDING_ADMIN);
+
+        events::publish_admin_transfer_cancelled(&env, current_admin, pending);
+
+        Ok(())
+    }
+
+    /// Get the pending admin address, if any.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&PENDING_ADMIN)
     }
 
     /// Configure per-address rate limiting for this contract.

--- a/contracts/zk_verifier/src/events.rs
+++ b/contracts/zk_verifier/src/events.rs
@@ -1,0 +1,61 @@
+use soroban_sdk::{symbol_short, Address, Env};
+
+/// Fired when an admin transfer is proposed.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Fired when an admin transfer is accepted.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Fired when a pending admin transfer is cancelled.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_proposed: Address,
+    pub timestamp: u64,
+}
+
+pub fn publish_admin_transfer_proposed(env: &Env, current_admin: Address, proposed_admin: Address) {
+    env.events().publish(
+        (symbol_short!("ADM_PROP"), current_admin.clone()),
+        AdminTransferProposedEvent {
+            current_admin,
+            proposed_admin,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn publish_admin_transfer_accepted(env: &Env, old_admin: Address, new_admin: Address) {
+    env.events().publish(
+        (symbol_short!("ADM_ACPT"), new_admin.clone()),
+        AdminTransferAcceptedEvent {
+            old_admin,
+            new_admin,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn publish_admin_transfer_cancelled(env: &Env, admin: Address, cancelled_proposed: Address) {
+    env.events().publish(
+        (symbol_short!("ADM_CNCL"), admin.clone()),
+        AdminTransferCancelledEvent {
+            admin,
+            cancelled_proposed,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}


### PR DESCRIPTION
Adds propose_admin, accept_admin, cancel_admin_transfer, and get_pending_admin to the following contracts:
- contracts/vision_records
- contracts/staking
- contracts/zk_verifier

Each step emits events (AdminTransferProposed, AdminTransferAccepted, AdminTransferCancelled) for indexing and monitoring.

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced admin transfer mechanisms with propose, accept, and cancel operations across staking, vision records, and ZK verifier contracts
  * Added event tracking for all admin transfer state transitions (proposals, acceptances, cancellations)
  * Enabled pending admin status queries for transparency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->