### PR TITLE
Replace SystemTime::now() with explicit now: u64 params for no_std co…

### DIFF
--- a/contracts/common/src/keys.rs
+++ b/contracts/common/src/keys.rs
@@ -23,9 +23,7 @@ pub struct AuditLog {
 }
 
 impl AuditLog {
-    pub fn record(&mut self, actor: &str, action: &str, target: &str) {
-        // Deterministic for host-side and contract-side execution.
-        let now = 0u64;
+    pub fn record(&mut self, actor: &str, action: &str, target: &str, now: u64) {
         self.entries.push(AuditEntry {
             actor: String::from(actor),
             action: String::from(action),
@@ -63,8 +61,7 @@ impl KeyManager {
         }
     }
 
-    pub fn create_data_key(&mut self, id: &str, key: Vec<u8>, ttl: Option<u64>) {
-        let now = 0u64;
+    pub fn create_data_key(&mut self, id: &str, key: Vec<u8>, ttl: Option<u64>, now: u64) {
         self.data_keys.insert(
             String::from(id),
             DataKey {
@@ -80,7 +77,7 @@ impl KeyManager {
         self.master = new_master;
     }
 
-    pub fn rotate_master_secure(&mut self, new_master: Vec<u8>, audit: &mut AuditLog, actor: &str) {
+    pub fn rotate_master_secure(&mut self, new_master: Vec<u8>, audit: &mut AuditLog, actor: &str, now: u64) {
         self.old_master = Some(self.master.clone());
 
         for dk in self.data_keys.values_mut() {
@@ -96,7 +93,7 @@ impl KeyManager {
             *b = 0;
         }
         self.master = new_master;
-        audit.record(actor, "rotate_master_secure", "master_key");
+        audit.record(actor, "rotate_master_secure", "master_key", now);
     }
 
     pub fn get_key(&self, id: &str) -> Option<&DataKey> {

--- a/contracts/common/src/keys_test.rs
+++ b/contracts/common/src/keys_test.rs
@@ -10,8 +10,8 @@ mod tests {
         // Setup initial master and data keys
         let old_master = vec![1, 2, 3, 4];
         let mut km = KeyManager::new(old_master.clone());
-        km.create_data_key("key1", vec![10, 20, 30], None);
-        km.create_data_key("key2", vec![40, 50, 60], None);
+        km.create_data_key("key1", vec![10, 20, 30], None, 1000);
+        km.create_data_key("key2", vec![40, 50, 60], None, 1000);
 
         // New master key
         let new_master = vec![5, 6, 7, 8];
@@ -20,7 +20,7 @@ mod tests {
         let mut audit = super::AuditLog::default();
 
         // Perform secure rotation
-        km.rotate_master_secure(new_master.clone(), &mut audit, "admin");
+        km.rotate_master_secure(new_master.clone(), &mut audit, "admin", 1000);
 
         // Check master key is new
         assert_eq!(km.master, new_master);

--- a/contracts/compliance/src/audit.rs
+++ b/contracts/compliance/src/audit.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 #[derive(Debug, Clone)]
 pub struct AuditEntry {
     pub actor: String,
@@ -15,11 +13,7 @@ pub struct AuditLog {
 
 impl AuditLog {
     /// Records an audit entry. For key rotation, use action="rotate_master_secure" and target="master_key".
-    pub fn record(&mut self, actor: &str, action: &str, target: &str) {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+    pub fn record(&mut self, actor: &str, action: &str, target: &str, now: u64) {
         self.entries.push(AuditEntry {
             actor: actor.to_string(),
             action: action.to_string(),

--- a/contracts/compliance/src/retention.rs
+++ b/contracts/compliance/src/retention.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 #[derive(Debug, Clone)]
 pub struct RetentionPolicy {
     pub id: String,
@@ -13,11 +11,7 @@ pub struct RetentionManager {
 }
 
 impl RetentionManager {
-    pub fn new() -> Self {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+    pub fn new(now: u64) -> Self {
         Self {
             policies: vec![],
             created_at: now,
@@ -31,13 +25,9 @@ impl RetentionManager {
         });
     }
 
-    pub fn should_purge(&self, created: u64, policy_id: &str) -> bool {
+    pub fn should_purge(&self, created: u64, policy_id: &str, now: u64) -> bool {
         if let Some(p) = self.policies.iter().find(|p| p.id == policy_id) {
-            return created.saturating_add(p.retention_seconds)
-                <= SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
+            return created.saturating_add(p.retention_seconds) <= now;
         }
         false
     }

--- a/contracts/compliance/tests/core.rs
+++ b/contracts/compliance/tests/core.rs
@@ -12,15 +12,15 @@ fn test_access_control_defaults() {
 #[test]
 fn test_audit_record() {
     let mut log = AuditLog::default();
-    log.record("user1", "read", "record:1");
+    log.record("user1", "read", "record:1", 1000);
     assert_eq!(log.query().len(), 1);
 }
 
 #[test]
 fn test_retention() {
-    let mut rm = RetentionManager::new();
+    let mut rm = RetentionManager::new(1000);
     rm.add_policy("phi", 1);
     // new records shouldn't be purged immediately
     let now = rm.created_at;
-    assert!(!rm.should_purge(now, "phi"));
+    assert!(!rm.should_purge(now, "phi", 1000));
 }

--- a/contracts/vision_records/tests/core.rs
+++ b/contracts/vision_records/tests/core.rs
@@ -456,7 +456,7 @@ fn test_encrypt_decrypt_roundtrip() {
     use common::KeyManager;
 
     let mut km = KeyManager::new(vec![0x0f, 0x1e, 0x2d, 0x3c]);
-    km.create_data_key("dkey1", vec![0xaa, 0xbb, 0xcc], None);
+    km.create_data_key("dkey1", vec![0xaa, 0xbb, 0xcc], None, 1000);
 
     let plaintext = "e3b0c44298fc1c149afbf4c8996fb924";
     let ciphertext = km.encrypt(Some("dkey1"), plaintext);


### PR DESCRIPTION
Closes: #125 

## Summary                                                                    
  - Remove `SystemTime::now()` from `compliance/src/retention.rs` and           
  `compliance/src/audit.rs`                                                     
  - Replace hardcoded `0u64` timestamps in `common/src/keys.rs` with explicit   
  `now: u64` parameters                                                         
  - Update `new()`, `record()`, `should_purge()`, `create_data_key()`, and      
  `rotate_master_secure()` signatures to receive `now: u64` 
  - Update all test call sites in `keys_test.rs`, `compliance/tests/core.rs`,
  and `vision_records/tests/core.rs`

  ## Motivation
  Soroban contracts run in a `no_std`/WASM environment where
  `std::time::SystemTime` is unavailable. By replacing all implicit timestamp
  generation with explicit `now: u64` parameters, the modules become
  deterministic and fully compatible with contract execution, where the ledger
  timestamp is passed in by the host.

  ## Test plan
  - [x] `cargo build -p common --all-targets` passes
  - [x] `cargo build -p compliance --all-targets` passes
  - [x] `cargo test -p common` — 1 test passed
  - [x] `cargo test -p compliance` — 3 tests passed
  - [x] No `SystemTime::now()` usage remains in contracts source code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated timestamp handling across audit logging, key management, and data retention systems to accept explicit time parameters rather than computing them internally. This enables more predictable and testable behavior in key creation, rotation, and audit tracking operations.

* **Tests**
  * Updated test suites to accommodate revised method signatures for timestamp-aware operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->