### PR TITLE
fix(orchestrator): repair clippy/test compilation for benchmarks

### DIFF
--- a/contracts/orchestrator/src/deadlock.rs
+++ b/contracts/orchestrator/src/deadlock.rs
@@ -64,9 +64,10 @@ impl<'a> DeadlockDetector<'a> {
         for i in 0..transactions.len() {
             let transaction = transactions.get(i).unwrap();
             if !visited.contains(transaction)
-                && self.dfs_has_cycle(graph, transaction, &mut visited, &mut recursion_stack) {
-                    return true;
-                }
+                && self.dfs_has_cycle(graph, transaction, &mut visited, &mut recursion_stack)
+            {
+                return true;
+            }
         }
 
         false
@@ -121,6 +122,7 @@ impl<'a> DeadlockDetector<'a> {
     }
 
     /// Get resources that are causing conflicts in a deadlock cycle
+    #[allow(dead_code)]
     fn get_conflicting_resources(&self, cycle: &Vec<u64>) -> Vec<String> {
         let current_locks: Vec<(String, u64)> = self
             .env

--- a/contracts/orchestrator/src/events.rs
+++ b/contracts/orchestrator/src/events.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{symbol_short, Address, Env, String, Vec};
 /// All symbol_short! values must be ≤9 characters.
 pub struct EventPublisher;
 
+#[allow(deprecated)]
 impl EventPublisher {
     /// Publish transaction started event
     pub fn transaction_started(env: &Env, log: &TransactionLog) {


### PR DESCRIPTION
Closes #275

## Summary
This PR fixes orchestrator test/clippy compilation issues caused by Soroban SDK API changes and missing test imports.

### What was fixed
- Updated `contracts/orchestrator/src/test_gas_benchmarks.rs`
  - Replaced deprecated `env.budget().consumed()` usage with:
    - `env.cost_estimate().budget().reset_default()`
    - `env.cost_estimate().budget().cpu_instruction_cost()`
  - Added missing test imports/macros (`testutils::Address`, `vec`).
  - Removed no-std-incompatible formatting paths that triggered compile errors.
  - Kept benchmark intent intact for gas-comparison tests.

- Updated `contracts/orchestrator/src/test_orchestrator.rs`
  - Added explicit crate imports instead of `use super::*` for test module resolution.
  - Added missing `testutils::Address` and `vec` imports.
  - Adjusted a few assertions/variables to satisfy strict clippy (`-D warnings`).

- Updated warnings in orchestrator internals
  - `contracts/orchestrator/src/events.rs`: added `#[allow(deprecated)]` on `EventPublisher` impl to avoid failing on existing `Events::publish` deprecation warnings.
  - `contracts/orchestrator/src/deadlock.rs`: added `#[allow(dead_code)]` to `get_conflicting_resources` helper.

## Validation
Passed locally:
- `cargo fmt -p orchestrator -- --check`
- `cargo check -p orchestrator`
- `cargo clippy -p orchestrator --all-targets -- -D warnings`

Terminal screenshot of passing checks is attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustments in conditional blocks

* **Tests**
  * Refactored gas benchmarking methodology for improved measurement accuracy
  * Expanded test infrastructure and improved test organization across multiple scenarios

* **Chores**
  * Added compiler directives to suppress deprecation and unused code warnings
  * Updated test imports for better code organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->