### PR TITLE
feat: implement unauthenticated admin access tests for key_manager

### DIFF
--- a/contracts/key_manager/tests/access_test.rs
+++ b/contracts/key_manager/tests/access_test.rs
@@ -1,0 +1,87 @@
+#![cfg(test)]
+
+use key_manager::{KeyManagerContract, KeyManagerContractClient, ContractError, KeyType, KeyPolicy, KeyLevel};
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec, symbol_short, BytesN};
+
+fn setup() -> (Env, KeyManagerContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KeyManagerContract, ());
+    let client = KeyManagerContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let identity_contract = Address::generate(&env);
+    client.initialize(&admin, &identity_contract);
+
+    (env, client, admin, identity_contract)
+}
+
+#[test]
+fn test_unauthenticated_admin_calls() {
+    let (env, client, _admin, identity_contract) = setup();
+    let unauthenticated_address = Address::generate(&env);
+
+    // 1. set_identity_contract should fail when called by a random address
+    let res_set_identity = client.try_set_identity_contract(&unauthenticated_address, &identity_contract);
+    assert_eq!(res_set_identity, Err(Ok(ContractError::Unauthorized)));
+
+    // 2. create_master_key should fail when called by a random address
+    let policy = KeyPolicy {
+        max_uses: 0,
+        not_before: 0,
+        not_after: 0,
+        allowed_ops: Vec::new(&env),
+    };
+    let key_bytes = BytesN::from_array(&env, &[0u8; 32]);
+    let res_create_master = client.try_create_master_key(
+        &unauthenticated_address, 
+        &KeyType::Signing, 
+        &policy, 
+        &0, 
+        &key_bytes
+    );
+    assert_eq!(res_create_master, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn test_unauthenticated_owner_level_calls() {
+    let (env, client, admin, _identity_contract) = setup();
+    
+    // Create a master key with admin to have a key_id for testing other calls
+    let policy = KeyPolicy {
+        max_uses: 0,
+        not_before: 0,
+        not_after: 0,
+        allowed_ops: Vec::new(&env),
+    };
+    let key_bytes = BytesN::from_array(&env, &[1u8; 32]);
+    let key_id = client.create_master_key(&admin, &KeyType::Signing, &policy, &0, &key_bytes);
+
+    let unauthenticated_address = Address::generate(&env);
+
+    // 3. derive_key should fail when called by a random address (not owner or admin)
+    let res_derive = client.try_derive_key(
+        &unauthenticated_address,
+        &key_id,
+        &KeyLevel::Contract,
+        &0,
+        &false,
+        &KeyType::Signing,
+        &policy,
+        &0,
+    );
+    assert_eq!(res_derive, Err(Ok(ContractError::Unauthorized)));
+
+    // 4. use_key should fail when called by a random address
+    let res_use = client.try_use_key(&unauthenticated_address, &key_id, &symbol_short!("OP"));
+    assert_eq!(res_use, Err(Ok(ContractError::Unauthorized)));
+
+    // 5. rotate_key should fail when called by a random address
+    let res_rotate = client.try_rotate_key(&unauthenticated_address, &key_id);
+    assert_eq!(res_rotate, Err(Ok(ContractError::Unauthorized)));
+
+    // 6. revoke_key should fail when called by a random address
+    let res_revoke = client.try_revoke_key(&unauthenticated_address, &key_id);
+    assert_eq!(res_revoke, Err(Ok(ContractError::Unauthorized)));
+}


### PR DESCRIPTION
# PR Description: Implement Unauthenticated Admin Function Calls Tests for Key Manager

## Overview
This PR adds robust test coverage for the `key_manager` smart contract to ensure that all administrative and owner-level functions are properly protected against unauthorized access. This strengthens the security of the Stellar-Wave backend by guaranteeing that only authorized addresses can perform sensitive key management operations.

## Related Issue
Closes #384

## Key Changes
- **New Test Suite**: Created [contracts/key_manager/tests/access_test.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/Teye-Contracts/contracts/key_manager/tests/access_test.rs:0:0-0:0).
- **Admin Authorization Checks**: Added tests to verify that [set_identity_contract](cci:1://file:///home/edohwares/Desktop/Room/drips/Teye-Contracts/contracts/key_manager/src/lib.rs:157:4-165:5) and [create_master_key](cci:1://file:///home/edohwares/Desktop/Room/drips/Teye-Contracts/contracts/key_manager/src/lib.rs:167:4-210:5) revert with `ContractError::Unauthorized` when called by an unauthenticated or non-admin address.
- **Owner/Admin Access Control**: Implemented tests for [derive_key](cci:1://file:///home/edohwares/Desktop/Room/drips/Teye-Contracts/contracts/key_manager/src/lib.rs:212:4-276:5), [use_key](cci:1://file:///home/edohwares/Desktop/Room/drips/Teye-Contracts/contracts/key_manager/src/lib.rs:278:4-302:5), [rotate_key](cci:1://file:///home/edohwares/Desktop/Room/drips/Teye-Contracts/contracts/key_manager/src/lib.rs:334:4-365:5), and [revoke_key](cci:1://file:///home/edohwares/Desktop/Room/drips/Teye-Contracts/contracts/key_manager/src/lib.rs:367:4-381:5) to ensure they reject calls from unauthorized random addresses.
- **Verification Logic**: Used `try_*` contract method calls to assert expected `Result::Err(Ok(ContractError::Unauthorized))` responses.

## Verification & Testing
Ran the following command in the `contracts/key_manager` directory:
```bash
cargo test --test access_test

Close #384 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive authorization tests for the key manager contract to validate that unauthorized access is properly blocked and rejected.
  * Tests cover both administrative operations and key management operations to ensure complete access control validation.
  * Confirms appropriate error responses are returned for unauthorized access attempts to maintain strong security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->