### PR TITLE
Add contract edge-case coverage for emr_bridge, delegation, and cross_chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "hex",
  "hmac",
  "sha2",
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/contracts/cross_chain/src/lib.rs
+++ b/contracts/cross_chain/src/lib.rs
@@ -10,7 +10,8 @@ pub use merkle_tree::{FieldProof, MerkleProof};
 pub use relay::StateRootAnchor;
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, String, Symbol,
+    contract, contractimpl, contracttype, symbol_short, vec, Address, Bytes, BytesN, Env, Error,
+    IntoVal, String, Symbol, Val,
 };
 
 /// Storage keys
@@ -41,6 +42,7 @@ pub enum CrossChainError {
     AlreadyProcessed = 4,
     UnknownIdentity = 5,
     UnsupportedAction = 6,
+    ExternalCallFailed = 7,
 }
 
 #[contract]
@@ -154,7 +156,7 @@ impl CrossChainContract {
         caller: Address,
         message_id: Bytes,
         message: CrossChainMessage,
-        _vision_contract: Address,
+        vision_contract: Address,
     ) -> Result<(), CrossChainError> {
         caller.require_auth();
 
@@ -191,12 +193,23 @@ impl CrossChainContract {
 
         // Handle the message based on target action
         if message.target_action == symbol_short!("GRANT") {
-            // TODO: Implement the actual cross-contract call to VisionRecords.
-            // The GRANT action requires the CrossChain contract to be an Admin or
-            // delegated by the user on the VisionRecords contract.
-            // Example:
-            // let client = VisionRecordsContractClient::new(&env, &vision_contract);
-            // client.grant_access(&env.current_contract_address(), &patient_addr, &grantee, &level, &duration);
+            let invoke_result = env.try_invoke_contract::<Val, Error>(
+                &vision_contract,
+                &Symbol::new(&env, "grant_cross_chain_access"),
+                vec![
+                    &env,
+                    env.current_contract_address().into_val(&env),
+                    _patient_addr.into_val(&env),
+                    message.payload.into_val(&env),
+                ],
+            );
+
+            match invoke_result {
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) | Err(Ok(_)) | Err(Err(_)) => {
+                    return Err(CrossChainError::ExternalCallFailed);
+                }
+            }
 
             env.storage().persistent().set(&processed_key, &true);
             env.storage()

--- a/contracts/cross_chain/src/test.rs
+++ b/contracts/cross_chain/src/test.rs
@@ -1,6 +1,29 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::{CrossChainContract, CrossChainContractClient, CrossChainError, CrossChainMessage};
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Bytes, Env, String};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, testutils::Address as _, Address, Bytes, Env, String,
+};
+
+#[contract]
+struct MockVisionRecords;
+
+#[contractimpl]
+impl MockVisionRecords {
+    pub fn grant_cross_chain_access(
+        env: Env,
+        bridge_caller: Address,
+        patient: Address,
+        payload: Bytes,
+    ) {
+        bridge_caller.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("PATIENT"), &patient);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("PAYLOAD"), &payload);
+    }
+}
 
 #[test]
 fn test_initialization() {
@@ -134,7 +157,7 @@ fn setup_process_message_env() -> (
 
     let admin = Address::generate(&env);
     let relayer = Address::generate(&env);
-    let vision_contract = Address::generate(&env);
+    let vision_contract = env.register(MockVisionRecords, ());
 
     client.initialize(&admin);
     client.add_relayer(&admin, &relayer);
@@ -156,7 +179,7 @@ fn test_process_message_grant_success() {
         source_chain: String::from_str(&env, "ethereum"),
         source_address: String::from_str(&env, "0xabc123"),
         target_action: symbol_short!("GRANT"),
-        payload: Bytes::new(&env),
+        payload: Bytes::from_slice(&env, &[1]),
     };
 
     // Should succeed
@@ -175,7 +198,7 @@ fn test_process_message_replay_fails() {
         source_chain: String::from_str(&env, "ethereum"),
         source_address: String::from_str(&env, "0xabc123"),
         target_action: symbol_short!("GRANT"),
-        payload: Bytes::new(&env),
+        payload: Bytes::from_slice(&env, &[1]),
     };
 
     // First call succeeds
@@ -216,7 +239,7 @@ fn test_process_message_unknown_identity_not_permanently_blocked() {
         source_chain: String::from_str(&env, "polygon"),
         source_address: String::from_str(&env, "0xnewuser"),
         target_action: symbol_short!("GRANT"),
-        payload: Bytes::new(&env),
+        payload: Bytes::from_slice(&env, &[1]),
     };
 
     // First attempt fails because identity is not mapped
@@ -267,7 +290,7 @@ fn test_process_message_non_relayer_fails() {
         source_chain: String::from_str(&env, "ethereum"),
         source_address: String::from_str(&env, "0xabc123"),
         target_action: symbol_short!("GRANT"),
-        payload: Bytes::new(&env),
+        payload: Bytes::from_slice(&env, &[1]),
     };
 
     // Non-relayer caller should fail with Unauthorized

--- a/contracts/cross_chain/tests/cross_contract_test.rs
+++ b/contracts/cross_chain/tests/cross_contract_test.rs
@@ -1,0 +1,144 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use cross_chain::{CrossChainContract, CrossChainContractClient, CrossChainError, CrossChainMessage};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, symbol_short, testutils::Address as _, Address, Bytes,
+    Env, String,
+};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+enum MockVisionError {
+    BadPayload = 1,
+}
+
+#[contract]
+struct MockVisionRecords;
+
+#[contractimpl]
+impl MockVisionRecords {
+    pub fn grant_cross_chain_access(
+        env: Env,
+        bridge_caller: Address,
+        patient: Address,
+        payload: Bytes,
+    ) -> Result<(), MockVisionError> {
+        bridge_caller.require_auth();
+
+        if payload.len() == 0 {
+            return Err(MockVisionError::BadPayload);
+        }
+
+        env.storage()
+            .instance()
+            .set(&symbol_short!("LAST_PAT"), &patient);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("LAST_PAY"), &payload);
+        Ok(())
+    }
+}
+
+fn s(env: &Env, value: &str) -> String {
+    String::from_str(env, value)
+}
+
+fn setup() -> (
+    Env,
+    CrossChainContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let bridge_id = env.register(CrossChainContract, ());
+    let vision_id = env.register(MockVisionRecords, ());
+
+    let client = CrossChainContractClient::new(&env, &bridge_id);
+    let admin = Address::generate(&env);
+    let relayer = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.add_relayer(&admin, &relayer);
+    client.map_identity(&admin, &s(&env, "ethereum"), &s(&env, "0xabc123"), &patient);
+
+    (env, client, admin, relayer, patient, vision_id)
+}
+
+#[test]
+fn test_process_message_invokes_mock_contract_and_forwards_payload() {
+    let (env, client, _admin, relayer, patient, vision_id) = setup();
+    let payload = Bytes::from_slice(&env, &[7, 8, 9]);
+    let message = CrossChainMessage {
+        source_chain: s(&env, "ethereum"),
+        source_address: s(&env, "0xabc123"),
+        target_action: symbol_short!("GRANT"),
+        payload: payload.clone(),
+    };
+    let message_id = Bytes::from_slice(&env, &[1, 2, 3, 4]);
+
+    client.process_message(&relayer, &message_id, &message, &vision_id);
+
+    let stored_patient: Address = env
+        .as_contract(&vision_id, || env.storage().instance().get(&symbol_short!("LAST_PAT")))
+        .expect("patient should be stored");
+    let stored_payload: Bytes = env
+        .as_contract(&vision_id, || env.storage().instance().get(&symbol_short!("LAST_PAY")))
+        .expect("payload should be stored");
+
+    assert_eq!(stored_patient, patient);
+    assert_eq!(stored_payload, payload);
+}
+
+#[test]
+fn test_process_message_external_contract_error_returns_external_call_failed() {
+    let (env, client, _admin, relayer, _patient, vision_id) = setup();
+    let message = CrossChainMessage {
+        source_chain: s(&env, "ethereum"),
+        source_address: s(&env, "0xabc123"),
+        target_action: symbol_short!("GRANT"),
+        payload: Bytes::new(&env),
+    };
+    let message_id = Bytes::from_slice(&env, &[9, 9, 9, 9]);
+
+    assert_eq!(
+        client.try_process_message(&relayer, &message_id, &message, &vision_id),
+        Err(Ok(CrossChainError::ExternalCallFailed))
+    );
+}
+
+#[test]
+fn test_failed_external_call_does_not_mark_message_processed() {
+    let (env, client, _admin, relayer, _patient, vision_id) = setup();
+    let failing = CrossChainMessage {
+        source_chain: s(&env, "ethereum"),
+        source_address: s(&env, "0xabc123"),
+        target_action: symbol_short!("GRANT"),
+        payload: Bytes::new(&env),
+    };
+    let success_payload = Bytes::from_slice(&env, &[1]);
+    let succeeding = CrossChainMessage {
+        source_chain: s(&env, "ethereum"),
+        source_address: s(&env, "0xabc123"),
+        target_action: symbol_short!("GRANT"),
+        payload: success_payload.clone(),
+    };
+    let message_id = Bytes::from_slice(&env, &[5, 4, 3, 2]);
+
+    assert_eq!(
+        client.try_process_message(&relayer, &message_id, &failing, &vision_id),
+        Err(Ok(CrossChainError::ExternalCallFailed))
+    );
+
+    client.process_message(&relayer, &message_id, &succeeding, &vision_id);
+
+    let stored_payload: Bytes = env
+        .as_contract(&vision_id, || env.storage().instance().get(&symbol_short!("LAST_PAY")))
+        .expect("payload should be stored after retry");
+    assert_eq!(stored_payload, success_payload);
+}

--- a/contracts/cross_chain/tests/math_test.rs
+++ b/contracts/cross_chain/tests/math_test.rs
@@ -1,0 +1,110 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use cross_chain::{
+    bridge::{export_record, import_record, AnchoredRoot, BridgeError},
+    relay,
+    StateRootAnchor,
+};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short,
+    testutils::Ledger as _,
+    BytesN, Env, Symbol,
+};
+
+const TTL_SAFETY_MARGIN: u32 = 600_000;
+
+#[contract]
+struct MathHarness;
+
+#[contractimpl]
+impl MathHarness {}
+
+fn setup() -> (Env, soroban_sdk::Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MathHarness, ());
+    (env, contract_id)
+}
+
+#[test]
+fn test_get_latest_root_handles_high_ledger_values_without_overflow() {
+    let (env, harness_id) = setup();
+    let safe_sequence = u32::MAX - TTL_SAFETY_MARGIN;
+    let chain_id: Symbol = symbol_short!("ETH");
+    let root = BytesN::from_array(&env, &[0xAB; 32]);
+    let anchor = StateRootAnchor {
+        root: root.clone(),
+        ledger_sequence: safe_sequence,
+        chain_id: chain_id.clone(),
+        anchored_at: 1,
+    };
+
+    env.as_contract(&harness_id, || {
+        env.storage().persistent().set(
+            &(symbol_short!("RELAYROOT"), chain_id.clone(), safe_sequence),
+            &anchor,
+        );
+        env.storage()
+            .persistent()
+            .set(&(symbol_short!("RELAYLST"), chain_id.clone()), &safe_sequence);
+    });
+
+    let latest = env
+        .as_contract(&harness_id, || relay::get_latest_root(&env, chain_id))
+        .expect("latest root should be present");
+    assert_eq!(latest.root, root);
+    assert_eq!(latest.ledger_sequence, safe_sequence);
+    assert_eq!(latest.anchored_at, 1);
+}
+
+#[test]
+fn test_import_record_detects_finality_overflow_instead_of_wrapping() {
+    let (env, harness_id) = setup();
+    env.ledger().set_sequence_number(100);
+    env.ledger().set_timestamp(1);
+
+    let record_id = BytesN::from_array(&env, &[0x11; 32]);
+    let package = export_record(
+        &env,
+        record_id,
+        soroban_sdk::Bytes::from_slice(&env, &[0x55]),
+        soroban_sdk::Vec::new(&env),
+        None,
+        symbol_short!("ETH"),
+    );
+    let root = package.state_root.clone();
+
+    env.as_contract(&harness_id, || {
+        let anchor_key = (symbol_short!("BRDG_RT"), root.clone());
+        let anchor_record = AnchoredRoot {
+            root: root.clone(),
+            anchored_at: u32::MAX - 1,
+            source_chain: symbol_short!("ETH"),
+        };
+        env.storage().persistent().set(&anchor_key, &anchor_record);
+        assert_eq!(
+            import_record(&env, package.clone(), root.clone(), 10),
+            Err(BridgeError::ChainReorgDetected)
+        );
+    });
+}
+
+#[test]
+fn test_export_record_preserves_max_timestamp_without_underflow() {
+    let (env, _harness_id) = setup();
+    env.ledger().set_timestamp(u64::MAX);
+
+    let record_id = BytesN::from_array(&env, &[0x22; 32]);
+    let package = export_record(
+        &env,
+        record_id.clone(),
+        soroban_sdk::Bytes::from_slice(&env, &[0xAA]),
+        soroban_sdk::Vec::new(&env),
+        None,
+        symbol_short!("ETH"),
+    );
+
+    assert_eq!(package.record_id, record_id);
+    assert_eq!(package.timestamp, u64::MAX);
+}

--- a/contracts/delegation/tests/validation_test.rs
+++ b/contracts/delegation/tests/validation_test.rs
@@ -1,0 +1,134 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use soroban_sdk::{testutils::Address as _, Address, Bytes, BytesN, Env};
+use teye_delegation::{
+    task_queue::TaskStatus, DelegationContract, DelegationContractClient,
+};
+
+fn setup() -> (Env, DelegationContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(DelegationContract, ());
+    let client = DelegationContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, client)
+}
+
+fn zero_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0; 32])
+}
+
+fn proof_for(env: &Env, input: &BytesN<32>, result: &BytesN<32>) -> BytesN<32> {
+    let mut payload = [0u8; 64];
+    payload[..32].copy_from_slice(&input.to_array());
+    payload[32..].copy_from_slice(&result.to_array());
+    let proof = env.crypto().sha256(&Bytes::from_slice(env, &payload));
+    BytesN::from_array(env, &proof.to_array())
+}
+
+#[test]
+fn test_submit_task_accepts_zero_priority_deadline_and_input_hash() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let input = zero_hash(&env);
+
+    let task_id = client.submit_task(&creator, &input, &0, &0);
+    let task = client.get_task(&task_id).expect("task should be stored");
+
+    assert_eq!(task.id, 1);
+    assert_eq!(task.priority, 0);
+    assert_eq!(task.deadline, 0);
+    assert_eq!(task.input_data, input);
+    assert_eq!(task.status, TaskStatus::Pending);
+}
+
+#[test]
+fn test_assign_task_zero_id_reverts_and_preserves_real_task_state() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let input = zero_hash(&env);
+
+    let task_id = client.submit_task(&creator, &input, &0, &0);
+    client.register_executor(&executor);
+
+    assert!(client.try_assign_task(&executor, &0).is_err());
+
+    let task = client.get_task(&task_id).expect("task should still exist");
+    assert_eq!(task.status, TaskStatus::Pending);
+    assert_eq!(task.executor, None);
+}
+
+#[test]
+fn test_submit_result_zero_hashes_with_matching_proof_completes_task() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let input = zero_hash(&env);
+    let result = zero_hash(&env);
+    let proof = proof_for(&env, &input, &result);
+
+    let task_id = client.submit_task(&creator, &input, &0, &0);
+    client.register_executor(&executor);
+    client.assign_task(&executor, &task_id);
+    client.submit_result(&executor, &task_id, &result, &proof);
+
+    let task = client.get_task(&task_id).expect("task should exist");
+    let executor_info = client
+        .get_executor_info(&executor)
+        .expect("executor should exist");
+
+    assert_eq!(task.status, TaskStatus::Completed);
+    assert_eq!(task.result, Some(result));
+    assert_eq!(executor_info.tasks_completed, 1);
+    assert_eq!(executor_info.reputation, 101);
+}
+
+#[test]
+fn test_submit_result_zero_id_reverts_without_mutating_executor() {
+    let (env, client) = setup();
+    let executor = Address::generate(&env);
+    client.register_executor(&executor);
+
+    let info_before = client
+        .get_executor_info(&executor)
+        .expect("executor should exist");
+    assert!(client
+        .try_submit_result(&executor, &0, &zero_hash(&env), &zero_hash(&env))
+        .is_err());
+
+    let info_after = client
+        .get_executor_info(&executor)
+        .expect("executor should still exist");
+    assert_eq!(info_after.tasks_completed, info_before.tasks_completed);
+    assert_eq!(info_after.reputation, info_before.reputation);
+}
+
+#[test]
+fn test_submit_result_zero_proof_marks_task_failed_and_slashes_executor() {
+    let (env, client) = setup();
+    let creator = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let input = zero_hash(&env);
+    let result = BytesN::from_array(&env, &[1; 32]);
+    let invalid_zero_proof = zero_hash(&env);
+
+    let task_id = client.submit_task(&creator, &input, &0, &0);
+    client.register_executor(&executor);
+    client.assign_task(&executor, &task_id);
+    client.submit_result(&executor, &task_id, &result, &invalid_zero_proof);
+
+    let task = client.get_task(&task_id).expect("task should exist");
+    let executor_info = client
+        .get_executor_info(&executor)
+        .expect("executor should exist");
+
+    assert_eq!(task.status, TaskStatus::Failed);
+    assert_eq!(task.result, None);
+    assert_eq!(executor_info.reputation, 90);
+    assert_eq!(executor_info.tasks_completed, 0);
+}

--- a/contracts/emr_bridge/tests/access_test.rs
+++ b/contracts/emr_bridge/tests/access_test.rs
@@ -1,0 +1,180 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use emr_bridge::{
+    types::{DataFormat, EmrSystem, ExchangeDirection, SyncStatus},
+    EmrBridgeContract, EmrBridgeContractClient, EmrBridgeError,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+fn s(env: &Env, value: &str) -> String {
+    String::from_str(env, value)
+}
+
+fn setup() -> (Env, EmrBridgeContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(EmrBridgeContract, ());
+    let client = EmrBridgeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, client, admin, attacker)
+}
+
+fn register_active_provider(
+    env: &Env,
+    client: &EmrBridgeContractClient<'_>,
+    admin: &Address,
+) -> String {
+    let provider_id = s(env, "provider-1");
+    client.register_provider(
+        admin,
+        &provider_id,
+        &s(env, "Provider One"),
+        &EmrSystem::EpicFhir,
+        &s(env, "https://provider.example"),
+        &DataFormat::FhirR4,
+    );
+    client.activate_provider(admin, &provider_id);
+    provider_id
+}
+
+fn create_exchange(
+    env: &Env,
+    client: &EmrBridgeContractClient<'_>,
+    admin: &Address,
+    provider_id: &String,
+) -> String {
+    let exchange_id = s(env, "exchange-1");
+    client.record_data_exchange(
+        admin,
+        &exchange_id,
+        provider_id,
+        &s(env, "patient-1"),
+        &ExchangeDirection::Import,
+        &DataFormat::FhirR4,
+        &s(env, "Patient"),
+        &s(env, "hash-1"),
+    );
+    exchange_id
+}
+
+#[test]
+fn test_register_provider_random_address_is_unauthorized() {
+    let (env, client, _admin, attacker) = setup();
+
+    assert_eq!(
+        client.try_register_provider(
+            &attacker,
+            &s(&env, "provider-1"),
+            &s(&env, "Provider One"),
+            &EmrSystem::EpicFhir,
+            &s(&env, "https://provider.example"),
+            &DataFormat::FhirR4,
+        ),
+        Err(Ok(EmrBridgeError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_activate_provider_random_address_is_unauthorized() {
+    let (env, client, admin, attacker) = setup();
+    let provider_id = register_active_provider(&env, &client, &admin);
+
+    assert_eq!(
+        client.try_suspend_provider(&attacker, &provider_id),
+        Err(Ok(EmrBridgeError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_suspend_provider_random_address_is_unauthorized() {
+    let (env, client, admin, attacker) = setup();
+    let provider_id = s(&env, "provider-1");
+    client.register_provider(
+        &admin,
+        &provider_id,
+        &s(&env, "Provider One"),
+        &EmrSystem::EpicFhir,
+        &s(&env, "https://provider.example"),
+        &DataFormat::FhirR4,
+    );
+
+    assert_eq!(
+        client.try_activate_provider(&attacker, &provider_id),
+        Err(Ok(EmrBridgeError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_record_data_exchange_random_address_is_unauthorized() {
+    let (env, client, admin, attacker) = setup();
+    let provider_id = register_active_provider(&env, &client, &admin);
+
+    assert_eq!(
+        client.try_record_data_exchange(
+            &attacker,
+            &s(&env, "exchange-1"),
+            &provider_id,
+            &s(&env, "patient-1"),
+            &ExchangeDirection::Import,
+            &DataFormat::FhirR4,
+            &s(&env, "Patient"),
+            &s(&env, "hash-1"),
+        ),
+        Err(Ok(EmrBridgeError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_update_exchange_status_random_address_is_unauthorized() {
+    let (env, client, admin, attacker) = setup();
+    let provider_id = register_active_provider(&env, &client, &admin);
+    let exchange_id = create_exchange(&env, &client, &admin, &provider_id);
+
+    assert_eq!(
+        client.try_update_exchange_status(&attacker, &exchange_id, &SyncStatus::Completed),
+        Err(Ok(EmrBridgeError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_create_field_mapping_random_address_is_unauthorized() {
+    let (env, client, admin, attacker) = setup();
+    let provider_id = register_active_provider(&env, &client, &admin);
+
+    assert_eq!(
+        client.try_create_field_mapping(
+            &attacker,
+            &s(&env, "mapping-1"),
+            &provider_id,
+            &s(&env, "source"),
+            &s(&env, "target"),
+            &s(&env, "identity"),
+        ),
+        Err(Ok(EmrBridgeError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_verify_sync_random_address_is_unauthorized() {
+    let (env, client, admin, attacker) = setup();
+    let provider_id = register_active_provider(&env, &client, &admin);
+    let exchange_id = create_exchange(&env, &client, &admin, &provider_id);
+    let discrepancies: Vec<String> = Vec::new(&env);
+
+    assert_eq!(
+        client.try_verify_sync(
+            &attacker,
+            &s(&env, "verification-1"),
+            &exchange_id,
+            &s(&env, "source-hash"),
+            &s(&env, "target-hash"),
+            &discrepancies,
+        ),
+        Err(Ok(EmrBridgeError::Unauthorized))
+    );
+}

--- a/contracts/metering/Cargo.toml
+++ b/contracts/metering/Cargo.toml
@@ -29,7 +29,3 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]
-
-[[test]]
-name = "init_test"
-path = "tests/init_test.rs"


### PR DESCRIPTION
## Summary
This PR expands edge-case coverage across three contract crates and tightens one missing runtime path in cross_chain so the new tests exercise real behavior instead of a stub.

## What Changed
### emr_bridge
- Added `access_test.rs` coverage for admin-only entrypoints.
- Verified that random non-admin callers receive `Unauthorized` for:
  - provider registration
  - provider activation and suspension
  - data exchange recording
  - exchange status updates
  - field mapping creation
  - sync verification

### delegation
- Added `validation_test.rs` coverage for zero-value edge cases.
- Exercised zero-valued hashes, zero priority, zero deadline, and zero task IDs against state-modifying flows.
- Verified that valid zero-value combinations still behave deterministically, while invalid zero-ID operations revert without corrupting task or executor state.

### cross_chain
- Added `cross_contract_test.rs` coverage for cross-contract calling invariants.
- Added `math_test.rs` coverage for high-boundary arithmetic paths, including the finality overflow branch in record import logic.
- Updated `process_message` so `GRANT` messages now attempt the external bridge callback and return a typed `ExternalCallFailed` error when the downstream contract call fails.
- Refreshed in-crate cross_chain tests to use a mock target contract and payloads that match the implemented runtime path.

### Test Execution Fix
- Removed a duplicate `init_test` declaration from `contracts/metering/Cargo.toml` so contract-level Cargo test invocations can run cleanly.

## Why
The linked issues all ask for stronger edge-case coverage around authorization, zero-value handling, cross-contract behavior, and arithmetic boundaries. The cross_chain contract still had a TODO in the exact path the requested tests were supposed to verify, so this PR closes that gap with the smallest implementation needed to make the invariant meaningful.

## Testing
- `cargo test --manifest-path contracts/emr_bridge/Cargo.toml`
- `cargo test --manifest-path contracts/delegation/Cargo.toml`
- `cargo test --manifest-path contracts/cross_chain/Cargo.toml`

Closes #344
Closes #337
Closes #333
Closes #331
