### PR TITLE
test: expand staking/key_manager/metering coverage

### DIFF
--- a/contracts/key_manager/src/lib.rs
+++ b/contracts/key_manager/src/lib.rs
@@ -478,7 +478,7 @@ impl KeyManagerContract {
     ) -> Result<u32, ContractError> {
         caller.require_auth();
         let record = Self::load_key_record(&env, &key_id)?;
-        let (_guardians, threshold) = Self::load_guardians(&env, &record.owner)?;
+        let (guardians, threshold) = Self::load_guardians(&env, &record.owner)?;
 
         let key = (RECOVERY, key_id.clone());
         let request: RecoveryRequest = env
@@ -487,7 +487,22 @@ impl KeyManagerContract {
             .get(&key)
             .ok_or(ContractError::RecoveryNotActive)?;
 
-        if request.approvals.len() < threshold {
+        // Revalidate approvals against the *current* guardian set so that
+        // stale approvals are invalidated when guardian membership changes.
+        if threshold == 0 || guardians.len() == 0 {
+            return Err(ContractError::InsufficientApprovals);
+        }
+
+        let mut valid_approvals: u32 = 0;
+        for i in 0..request.approvals.len() {
+            if let Some(approver) = request.approvals.get(i) {
+                if guardians.contains(&approver) {
+                    valid_approvals = valid_approvals.saturating_add(1);
+                }
+            }
+        }
+
+        if valid_approvals < threshold {
             return Err(ContractError::InsufficientApprovals);
         }
 

--- a/contracts/key_manager/tests/core.rs
+++ b/contracts/key_manager/tests/core.rs
@@ -146,3 +146,81 @@ fn test_hierarchy_validation() {
     );
     assert!(matches!(err, Err(Ok(ContractError::InvalidHierarchy))));
 }
+
+#[test]
+fn test_recovery_cooldown_is_enforced_before_execution() {
+    let (env, client, identity, admin) = setup();
+
+    let guardian1 = Address::generate(&env);
+    let guardian2 = Address::generate(&env);
+    let guardian3 = Address::generate(&env);
+
+    identity.add_guardian(&admin, &guardian1);
+    identity.add_guardian(&admin, &guardian2);
+    identity.add_guardian(&admin, &guardian3);
+    identity.set_recovery_threshold(&admin, &2);
+
+    let policy = KeyPolicy {
+        max_uses: 0,
+        not_before: 0,
+        not_after: 0,
+        allowed_ops: Vec::new(&env),
+    };
+
+    let key_bytes = BytesN::from_array(&env, &[13u8; 32]);
+    let key_id = client.create_master_key(&admin, &KeyType::Encryption, &policy, &0u64, &key_bytes);
+
+    let replacement = BytesN::from_array(&env, &[14u8; 32]);
+    client.initiate_recovery(&guardian1, &key_id, &replacement);
+    client.approve_recovery(&guardian2, &key_id);
+
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 86_400);
+    let early = client.try_execute_recovery(&admin, &key_id);
+    assert_eq!(early, Err(Ok(ContractError::CooldownNotExpired)));
+
+    env.ledger().set_timestamp(now + 86_401);
+    let version = client.execute_recovery(&admin, &key_id);
+    let current = client.get_key_version(&key_id, &version).unwrap();
+    assert_eq!(current.key_bytes, replacement);
+}
+
+#[test]
+fn test_only_designated_guardians_can_start_and_approve_recovery() {
+    let (env, client, identity, admin) = setup();
+
+    let guardian1 = Address::generate(&env);
+    let guardian2 = Address::generate(&env);
+    let guardian3 = Address::generate(&env);
+    let outsider = Address::generate(&env);
+
+    identity.add_guardian(&admin, &guardian1);
+    identity.add_guardian(&admin, &guardian2);
+    identity.add_guardian(&admin, &guardian3);
+    identity.set_recovery_threshold(&admin, &2);
+
+    let policy = KeyPolicy {
+        max_uses: 0,
+        not_before: 0,
+        not_after: 0,
+        allowed_ops: Vec::new(&env),
+    };
+
+    let key_bytes = BytesN::from_array(&env, &[15u8; 32]);
+    let key_id = client.create_master_key(&admin, &KeyType::Encryption, &policy, &0u64, &key_bytes);
+    let replacement = BytesN::from_array(&env, &[16u8; 32]);
+
+    let denied_initiate = client.try_initiate_recovery(&outsider, &key_id, &replacement);
+    assert_eq!(denied_initiate, Err(Ok(ContractError::NotAGuardian)));
+
+    client.initiate_recovery(&guardian1, &key_id, &replacement);
+
+    let denied_approve = client.try_approve_recovery(&outsider, &key_id);
+    assert_eq!(denied_approve, Err(Ok(ContractError::NotAGuardian)));
+
+    client.approve_recovery(&guardian2, &key_id);
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 86_401);
+    let version = client.execute_recovery(&admin, &key_id);
+    assert_eq!(version, 2);
+}

--- a/contracts/key_manager/tests/cross_contract_test.rs
+++ b/contracts/key_manager/tests/cross_contract_test.rs
@@ -221,3 +221,80 @@ fn use_key_invariants_remain_intact_after_cross_contract_recovery_failures() {
     let current = client.use_key(&admin, &key_id, &symbol_short!("ENC"));
     assert_eq!(current, BytesN::from_array(&env, &[31u8; 32]));
 }
+
+#[test]
+fn threshold_update_requires_new_guardian_approval_before_execute() {
+    let (env, client, admin, identity_id, guardian1, guardian2, _outsider) = setup();
+    let key_id = create_master_key(&env, &client, &admin, 41);
+    let replacement = BytesN::from_array(&env, &[42u8; 32]);
+
+    client.initiate_recovery(&guardian1, &key_id, &replacement);
+    client.approve_recovery(&guardian2, &key_id);
+
+    let guardian3 = Address::generate(&env);
+    let identity = MockIdentityContractClient::new(&env, &identity_id);
+    let mut guardians = Vec::new(&env);
+    guardians.push_back(guardian1.clone());
+    guardians.push_back(guardian2.clone());
+    guardians.push_back(guardian3.clone());
+    identity.configure(&guardians, &3, &false, &false);
+
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 86_401);
+
+    let blocked = client.try_execute_recovery(&admin, &key_id);
+    assert_eq!(blocked, Err(Ok(ContractError::InsufficientApprovals)));
+
+    client.approve_recovery(&guardian3, &key_id);
+    let version = client.execute_recovery(&admin, &key_id);
+    assert_eq!(version, 2);
+}
+
+#[test]
+fn removed_guardian_approval_is_invalidated() {
+    let (env, client, admin, identity_id, guardian1, guardian2, _outsider) = setup();
+    let key_id = create_master_key(&env, &client, &admin, 51);
+    let replacement = BytesN::from_array(&env, &[52u8; 32]);
+
+    client.initiate_recovery(&guardian1, &key_id, &replacement);
+    client.approve_recovery(&guardian2, &key_id);
+
+    let guardian3 = Address::generate(&env);
+    let identity = MockIdentityContractClient::new(&env, &identity_id);
+    let mut guardians = Vec::new(&env);
+    guardians.push_back(guardian1.clone());
+    guardians.push_back(guardian3.clone());
+    identity.configure(&guardians, &2, &false, &false);
+
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 86_401);
+
+    let blocked = client.try_execute_recovery(&admin, &key_id);
+    assert_eq!(blocked, Err(Ok(ContractError::InsufficientApprovals)));
+
+    client.approve_recovery(&guardian3, &key_id);
+    let version = client.execute_recovery(&admin, &key_id);
+    assert_eq!(version, 2);
+}
+
+#[test]
+fn zero_threshold_configuration_cannot_execute_recovery() {
+    let (env, client, admin, identity_id, guardian1, guardian2, _outsider) = setup();
+    let key_id = create_master_key(&env, &client, &admin, 61);
+    let replacement = BytesN::from_array(&env, &[62u8; 32]);
+
+    client.initiate_recovery(&guardian1, &key_id, &replacement);
+    client.approve_recovery(&guardian2, &key_id);
+
+    let identity = MockIdentityContractClient::new(&env, &identity_id);
+    let mut guardians = Vec::new(&env);
+    guardians.push_back(guardian1);
+    guardians.push_back(guardian2);
+    identity.configure(&guardians, &0, &false, &false);
+
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 86_401);
+
+    let blocked = client.try_execute_recovery(&admin, &key_id);
+    assert_eq!(blocked, Err(Ok(ContractError::InsufficientApprovals)));
+}

--- a/contracts/metering/src/lib.rs
+++ b/contracts/metering/src/lib.rs
@@ -552,12 +552,6 @@ impl MeteringContract {
 
         let cycle_id = billing::close_cycle(&env).map_err(map_billing_error)?;
 
-        let costs: GasCosts = env
-            .storage()
-            .instance()
-            .get(&GAS_COSTS)
-            .unwrap_or_else(GasCosts::default_costs);
-
         let list: Vec<Address> = env
             .storage()
             .persistent()
@@ -570,12 +564,10 @@ impl MeteringContract {
             if let Some(addr) = list.get(i) {
                 let usage = quota::get_usage(&env, &addr);
 
-                let total_cost = usage
-                    .read_used
-                    .saturating_mul(costs.read_cost)
-                    .saturating_add(usage.write_used.saturating_mul(costs.write_cost))
-                    .saturating_add(usage.compute_used.saturating_mul(costs.compute_cost))
-                    .saturating_add(usage.storage_used.saturating_mul(costs.storage_cost));
+                // Usage buckets already store metered gas units at record time.
+                // Summing the buckets avoids retroactive re-pricing and keeps
+                // billing stable when gas costs are updated mid-cycle.
+                let total_cost = usage.total();
 
                 let record = TenantUsageRecord {
                     tenant: addr.clone(),

--- a/contracts/metering/src/test.rs
+++ b/contracts/metering/src/test.rs
@@ -753,3 +753,82 @@ fn test_gas_token_account_snapshot() {
     assert_eq!(account.balance, 200);
     assert!(!account.frozen);
 }
+
+#[test]
+fn test_long_running_and_short_burst_usage_are_billed_precisely() {
+    let (env, client, admin) = setup();
+    let org = register_org(&client, &admin, &env);
+
+    client.open_billing_cycle(&admin);
+
+    // Long-running background read load: 100 x 1 unit.
+    for _ in 0..100 {
+        client.record_gas(&admin, &org, &OperationType::Read);
+    }
+
+    // Short burst compute spike: 2 x 10 units.
+    for _ in 0..2 {
+        client.record_gas(&admin, &org, &OperationType::Compute);
+    }
+
+    let report = client.close_billing_cycle(&admin);
+    let record = report.records.get(0).unwrap();
+
+    assert_eq!(record.read_units, 100);
+    assert_eq!(record.compute_units, 20);
+    assert_eq!(record.total_cost, 120);
+}
+
+#[test]
+fn test_dynamic_pricing_only_affects_future_metered_usage() {
+    let (env, client, admin) = setup();
+    let org = register_org(&client, &admin, &env);
+
+    client.open_billing_cycle(&admin);
+
+    // First read at default price (1).
+    client.record_gas(&admin, &org, &OperationType::Read);
+
+    // Raise read cost from 1 to 7. Only future usage should use the new cost.
+    let updated_costs = GasCosts {
+        read_cost: 7,
+        write_cost: 5,
+        compute_cost: 10,
+        storage_cost: 3,
+    };
+    client.set_gas_costs(&admin, &updated_costs);
+
+    client.record_gas(&admin, &org, &OperationType::Read);
+
+    let report = client.close_billing_cycle(&admin);
+    let record = report.records.get(0).unwrap();
+
+    // Metered units are recorded at operation time: 1 + 7.
+    assert_eq!(record.read_units, 8);
+    assert_eq!(record.total_cost, 8);
+}
+
+#[test]
+fn test_rounding_stays_in_base_units_without_fractional_drift() {
+    let (env, client, admin) = setup();
+    let org = register_org(&client, &admin, &env);
+
+    let custom_costs = GasCosts {
+        read_cost: 3,
+        write_cost: 6,
+        compute_cost: 9,
+        storage_cost: 4,
+    };
+    client.set_gas_costs(&admin, &custom_costs);
+
+    client.open_billing_cycle(&admin);
+    client.record_gas(&admin, &org, &OperationType::Read); // 3
+    client.record_gas(&admin, &org, &OperationType::Storage); // 4
+    client.record_gas(&admin, &org, &OperationType::Read); // 3
+
+    let report = client.close_billing_cycle(&admin);
+    let record = report.records.get(0).unwrap();
+
+    // 3 + 4 + 3 = 10 exact base units, no fractional rounding paths.
+    assert_eq!(record.total_cost, 10);
+}

--- a/contracts/staking/src/test.rs
+++ b/contracts/staking/src/test.rs
@@ -325,6 +325,51 @@ fn test_double_withdraw_fails() {
 }
 
 #[test]
+fn test_high_latency_does_not_apply_implicit_slashing() {
+    let (env, client, _admin, stake_token, _reward_token) = setup(10, 0);
+
+    let staker = Address::generate(&env);
+    mint_stake(&env, &stake_token, &staker, 1_000);
+
+    env.ledger().set_timestamp(0);
+    client.stake(&staker, &1_000);
+
+    // Simulate very delayed finality / network latency.
+    env.ledger().set_timestamp(86_400 * 7);
+    let _ = client.claim_rewards(&staker);
+
+    // Staked principal must be untouched unless explicit unstake/withdraw occurs.
+    assert_eq!(client.get_staked(&staker), 1_000);
+    assert_eq!(client.get_total_staked(), 1_000);
+}
+
+#[test]
+fn test_failed_early_withdraw_does_not_penalize_stake() {
+    let (env, client, _admin, stake_token, _reward_token) = setup(10, 86_400);
+
+    let staker = Address::generate(&env);
+    mint_stake(&env, &stake_token, &staker, 1_000);
+
+    env.ledger().set_timestamp(0);
+    client.stake(&staker, &1_000);
+    let request_id = client.request_unstake(&staker, &500);
+
+    // Withdraw attempted before timelock expiration should not burn/slash funds.
+    env.ledger().set_timestamp(300);
+    let early = client.try_withdraw(&staker, &request_id);
+    assert_eq!(early, Err(Ok(ContractError::TimelockNotExpired)));
+
+    assert_eq!(client.get_staked(&staker), 500);
+    let req = client.get_unstake_request(&request_id);
+    assert!(!req.withdrawn);
+
+    env.ledger().set_timestamp(86_401);
+    client.withdraw(&staker, &request_id);
+
+    assert_eq!(client.get_staked(&staker), 500);
+}
+
+#[test]
 fn test_unstake_more_than_staked_fails() {
     let (env, client, _admin, stake_token, _) = setup(10, 0);
 


### PR DESCRIPTION
- Harden key_manager recovery execution against stale guardian approvals after threshold or guardian-set changes

- Add key_manager tests for cooldown, guardian-only initiation/approval, threshold transitions, and approval invalidation

- Fix metering billing precision to avoid retroactive re-pricing at cycle close

- Add metering tests for long-run vs burst usage, dynamic pricing behavior, and base-unit rounding invariants

- Add staking latency anti-regression tests to prevent accidental stake penalties

Closes #467

Closes #468

Closes #469

Closes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery approval validation to verify each approval against the current guardian configuration, preventing execution if the threshold is not met.

* **Tests**
  * Added recovery cooldown enforcement and guardian authorization validation tests.
  * Added cross-contract recovery tests for dynamic guardian configuration scenarios.
  * Enhanced billing cycle cost aggregation and metering test coverage.
  * Added staking latency and withdrawal protection tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->